### PR TITLE
Fix loading overlay display conflict

### DIFF
--- a/pages/student-info.html
+++ b/pages/student-info.html
@@ -258,7 +258,7 @@
     </div>
 
     <!-- Loading Overlay -->
-    <div class="loading-overlay" id="loadingOverlay" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 9999; display: flex; align-items: center; justify-content: center;">
+    <div class="loading-overlay" id="loadingOverlay" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 9999; align-items: center; justify-content: center;">
         <div class="mobile-loading">
             <div class="mobile-spinner"></div>
             <p style="color: white; margin-top: var(--spacing-md);">Saving your information...</p>


### PR DESCRIPTION
Removes conflicting `display: flex` from loading overlay to ensure it is hidden by default.

The `#loadingOverlay` element in `pages/student-info.html` had both `display: none` and `display: flex` in its inline style attribute. Since `display: flex` appeared later, it overrode `display: none`, causing the overlay to be visible by default instead of hidden. This PR fixes the unintended default visibility.