### PR TITLE
Fix loading overlay display style to ensure proper visibility

### DIFF
--- a/pages/student-info.html
+++ b/pages/student-info.html
@@ -258,7 +258,7 @@
     </div>
 
     <!-- Loading Overlay -->
-    <div class="loading-overlay" id="loadingOverlay" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 9999; display: flex; align-items: center; justify-content: center;">
+    <div class="loading-overlay" id="loadingOverlay" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 9999; align-items: center; justify-content: center;">
         <div class="mobile-loading">
             <div class="mobile-spinner"></div>
             <p style="color: white; margin-top: var(--spacing-md);">Saving your information...</p>


### PR DESCRIPTION
This pull request includes a small change to the `pages/student-info.html` file. The change removes a duplicate `display: flex;` style from the `loading-overlay` div to clean up the inline CSS.